### PR TITLE
chore(telemetry): change trace method to accept static attributes dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pricelab-core"
-version = "0.4.26"
+version = "0.4.27"
 authors = [
     { name = "Toufik Saouchi", email = "toufik.saouchi@gmail.com" },
 ]

--- a/src/pricelab_core/infrastructure/telemetry/adapter/open_telemetry.py
+++ b/src/pricelab_core/infrastructure/telemetry/adapter/open_telemetry.py
@@ -66,12 +66,12 @@ class OpenTelemetryManager:
     def shutdown(self) -> None:
         self._provider.shutdown()
 
-    def trace(self, span_name: str, **static_attributes: Dict[str, Any]) -> TraceType:
+    def trace(self, span_name: str, static_attributes: Dict[str, Any]) -> TraceType:
         def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
             @wraps(func)
             async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
                 with self._tracer.start_as_current_span(span_name) as span:
-                    self._enrich_span(span, **static_attributes)
+                    self._enrich_span(span, static_attributes)
                     try:
                         result = await func(*args, **kwargs)
                         span.set_status(Status(StatusCode.OK))
@@ -86,7 +86,7 @@ class OpenTelemetryManager:
         return decorator
 
     @staticmethod
-    def _enrich_span(span, **static_attributes: Dict[str, Any]) -> None:
+    def _enrich_span(span, static_attributes: Dict[str, Any]) -> None:
 
         request_id = request_id_ctx.get()
 

--- a/src/pricelab_core/infrastructure/telemetry/port/telemetry.py
+++ b/src/pricelab_core/infrastructure/telemetry/port/telemetry.py
@@ -6,6 +6,6 @@ R = TypeVar("R")
 
 class Telemetry(Protocol):
     def trace(
-        self, span_name: str, **static_attributes: Dict[str, Any]
+        self, span_name: str, static_attributes: Dict[str, Any]
     ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]: ...
     def shutdown(self) -> None: ...


### PR DESCRIPTION
- Updated Telemetry protocol trace method to use static_attributes dict parameter
- Modified OpenTelemetry adapter trace method accordingly
- Updated _enrich_span method signature and calls to accept static_attributes dict
- Incremented project version to 0.4.27